### PR TITLE
when caching meteor, run it under test environment so we don't run mi…

### DIFF
--- a/app/.testing/cache_build_and_dependencies.js
+++ b/app/.testing/cache_build_and_dependencies.js
@@ -7,7 +7,7 @@ const srcDir = baseDir;
 
 const cacheMeteor = function() {
   console.log('Caching build & dependencies (can take a while the first time)');
-  const childProcess = spawn('meteor', ['--raw-logs'], {
+  const childProcess = spawn('meteor', ['test', '--full-app', '--driver-package', 'tmeasday:acceptance-test-driver', '--raw-logs'], {
     cwd: srcDir,
     env: process.env
   });


### PR DESCRIPTION
…grations. the htmeasday:acceptance-test-driver will prevent any tests from running though

fixes #216 