### PR TITLE
Updating lodash to 4.16.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bcrypt": "0.8.7",
     "faker": "3.1.0",
-    "lodash": "4.15.0",
+    "lodash": "4.16.4",
     "loggly": "1.1.1",
     "meteor-node-stubs": "0.2.3",
     "moment": "2.15.1",


### PR DESCRIPTION

Please update [lodash](https://npmjs.org/package/lodash) to version 4.16.4.

If this passes your tests you can merge it in.  If not please use this branch for changes.

