### PR TITLE
Updating moment-timezone to 0.5.6

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "loggly": "1.1.1",
     "meteor-node-stubs": "0.2.3",
     "moment": "2.15.1",
-    "moment-timezone": "0.5.5",
+    "moment-timezone": "0.5.6",
     "store": "1.3.20",
     "winston": "2.2.0",
     "winston-loggly-bulk": "1.3.3"


### PR DESCRIPTION

Please update [moment-timezone](https://npmjs.org/package/moment-timezone) to version 0.5.6.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```7ad329a```](https://github.com/moment/moment-timezone/commit/7ad329aa12e5abb86ea4faa6a5fc468b48bba526) ```version 0.5.6```
 * [```3c8eba1```](https://github.com/moment/moment-timezone/commit/3c8eba1949583d558696b48645b9741768305b2b) ```version 0.5.6```
 * [```cdcdaed```](https://github.com/moment/moment-timezone/commit/cdcdaed641e864620322d973d8e2526fd12e2e8b) ```Merge pull request #394 from ssskip/2016g```
 * [```5a4f7a3```](https://github.com/moment/moment-timezone/commit/5a4f7a32f70484c3ea1815c6b1b1725677c43112) ```update to  IANA 2016g data```
 * [```2243199```](https://github.com/moment/moment-timezone/commit/224319953ede55adf809c187386fb4d8856addb1) ```Merge pull request #392 from mj1856/tzversion```
 * [```8c3ef65```](https://github.com/moment/moment-timezone/commit/8c3ef65730238210db9987abddbb891dfd36eac4) ```Pull version from NEWS file for now.```
 * [```060ea59```](https://github.com/moment/moment-timezone/commit/060ea5947c78b60d3e59679cafd2cb1b170a752f) ```Merge pull request #376 from anotheredward/patch-1```
 * [```79639b4```](https://github.com/moment/moment-timezone/commit/79639b4e1e0e263e96f641d9335f119c292c355f) ```add license to bower.json```


View the [change log](https://github.com/moment/moment-timezone/compare/32ef9eff5781a7fa57f75a84caebedc905d2ab8a...7ad329aa12e5abb86ea4faa6a5fc468b48bba526).