### PR TITLE
Updating moment to 2.15.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "lodash": "4.16.4",
     "loggly": "1.1.1",
     "meteor-node-stubs": "0.2.3",
-    "moment": "2.15.1",
+    "moment": "2.15.2",
     "moment-timezone": "0.5.6",
     "store": "1.3.20",
     "winston": "2.2.0",


### PR DESCRIPTION

Please update [moment](https://npmjs.org/package/moment) to version 2.15.2.

If this passes your tests you can merge it in.  If not please use this branch for changes.

