### PR TITLE
Updating winston to 2.3.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "moment": "2.15.2",
     "moment-timezone": "0.5.6",
     "store": "1.3.20",
-    "winston": "2.2.0",
+    "winston": "2.3.0",
     "winston-loggly-bulk": "1.3.3"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "moment-timezone": "0.5.6",
     "store": "1.3.20",
     "winston": "2.3.0",
-    "winston-loggly-bulk": "1.3.3"
+    "winston-loggly-bulk": "1.3.4"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1582,7 +1582,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-loggly-bulk@~1.1.1:
+node-loggly-bulk@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/node-loggly-bulk/-/node-loggly-bulk-1.1.1.tgz#8860d2fc5abe434112178ccfb3cd07cb6682f86b"
   dependencies:
@@ -1728,10 +1728,6 @@ pkg-up@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
   dependencies:
     find-up "^1.0.0"
-
-pkginfo@0.3.x:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -2293,22 +2289,21 @@ which@^1.2.9, which@~1.2.10:
   dependencies:
     isexe "^1.1.1"
 
-winston-loggly-bulk@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/winston-loggly-bulk/-/winston-loggly-bulk-1.3.3.tgz#7210edd2bb4f856ddda32775cc5cf5757d2bebb0"
+winston-loggly-bulk@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/winston-loggly-bulk/-/winston-loggly-bulk-1.3.4.tgz#c87e4b3693c97308cb2d9c848cc01baf947a3ac8"
   dependencies:
-    node-loggly-bulk "~1.1.1"
+    node-loggly-bulk "~1.1.0"
 
-winston@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.2.0.tgz#2c853dd87ab552a8e8485d72cbbf9a2286f029b7"
+winston@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.3.0.tgz#207faaab6fccf3fe493743dd2b03dbafc7ceb78c"
   dependencies:
     async "~1.0.0"
     colors "1.0.x"
     cycle "1.0.x"
     eyes "0.1.x"
     isstream "0.1.x"
-    pkginfo "0.3.x"
     stack-trace "0.0.x"
 
 wordwrap@~1.0.0:


### PR DESCRIPTION

Please update [winston](https://npmjs.org/package/winston) to version 2.3.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```739d802```](https://github.com/winstonjs/winston/commit/739d8023c87183261dcae6ecc92c5b87a5eac961) ```[dist] Version bump. 2.3.0```
 * [```26664f4```](https://github.com/winstonjs/winston/commit/26664f4f18f09ebb9ff012a2157612e9bac921fd) ```[dist] Modernize .travis.yml again```
 * [```d9050b8```](https://github.com/winstonjs/winston/commit/d9050b8fa4e1e67d3c64ce376f27936045d452e6) ```[dist] Add short message for 2.2.0 until a full CH&hellip;```
 * [```c98e6c5```](https://github.com/winstonjs/winston/commit/c98e6c5558112e09eb111fe7dac5b7e324fc298c) ```Merge pull request #839 from vanthome/patch-1```
 * [```0198c17```](https://github.com/winstonjs/winston/commit/0198c175082dc142263cf6dabbe3db74cefa47f8) ```Merge pull request #852 from tamlyn/master```
 * [```c351649```](https://github.com/winstonjs/winston/commit/c3516494bb723d161dbe449ccf71136646f96f26) ```Merge pull request #858 from tarrow/patch-1```
 * [```55dac6d```](https://github.com/winstonjs/winston/commit/55dac6df40fafd8c837064aa7d717dc26fe39dad) ```Merge pull request #859 from davidadas/master```
 * [```ab926c3```](https://github.com/winstonjs/winston/commit/ab926c36e1e60b5127d643213fd7450275bd7a69) ```Merge pull request #882 from khowen/update-docs```
 * [```1dedee5```](https://github.com/winstonjs/winston/commit/1dedee5bcb26c92d96d66db46e9c89063e4d7985) ```Merge pull request #894 from pkallos/master```
 * [```162c50f```](https://github.com/winstonjs/winston/commit/162c50fd29864baa3ce21c9d0995e6bd5caff74e) ```Merge pull request #898 from sinkingpoint/master```
 * [```391a956```](https://github.com/winstonjs/winston/commit/391a956fbf66be7f82a9528d455d91fa22a66863) ```fix: use es5 only```
 * [```98fd982```](https://github.com/winstonjs/winston/commit/98fd9822af3bf97569a48b4d1e369ecc35669762) ```Update transports.js```
 * [```ddb8a2d```](https://github.com/winstonjs/winston/commit/ddb8a2d6a3db3f15713e2c654cd184f7428a1046) ```Update transports.js```
 * [```a8db2b3```](https://github.com/winstonjs/winston/commit/a8db2b3a75de71a17fd6f211630a37778fa85d4a) ```fix: remove expression dependencies```
 * [```07c70d1```](https://github.com/winstonjs/winston/commit/07c70d1e74c5b177936fb1500a6c61a7627db851) ```Update package.json```


See the full [change log](https://github.com/winstonjs/winston/compare/b44062612f63211d047c67050fef5b7624682fb6...739d8023c87183261dcae6ecc92c5b87a5eac961) for everything that changed in this release.