### PR TITLE
added --ignore-engines flag because Selenium technically requires Nod…

### DIFF
--- a/app/.testing/cache_npm_dependencies.sh
+++ b/app/.testing/cache_npm_dependencies.sh
@@ -5,4 +5,4 @@
 # if [ ! -e /home/ubuntu/nvm/versions/node/v4.8.1/lib/node_modules/spacejam/bin/spacejam ]; then yarn global add spacejam; fi
 
 echo "Installing local packages …"
-yarn --verbose
+yarn --verbose --ignore-engines


### PR DESCRIPTION
…e 6 and we're on 4.

fixes #388 